### PR TITLE
fixed mammouth upgrade typo

### DIFF
--- a/docs/mammouth-code/index.md
+++ b/docs/mammouth-code/index.md
@@ -155,7 +155,7 @@ There are 2 ways to continue a previous session:
 To update Mammouth Code to the latest version:
 
 ```bash
-mammouth update
+mammouth upgrade
 ```
 
 This will fetch and install the latest version, replacing the old one while keeping your configurations and sessions intact.

--- a/fr/docs/mammouth-code/index.md
+++ b/fr/docs/mammouth-code/index.md
@@ -155,7 +155,7 @@ Il y a 2 façons de reprendre une session précédente :
 Pour mettre à jour Mammouth Code vers la dernière version :
 
 ```bash
-mammouth update
+mammouth upgrade
 ```
 
 Cela récupérera et installera la dernière version, remplaçant l'ancienne tout en conservant vos configurations et sessions.


### PR DESCRIPTION
Way to upgrade Mammouth Code was documented incorrectly, so I fixed it here.
Was `mammouth update`, correct command is `mammouth upgrade`, hence this PR.